### PR TITLE
changed bot.readyTime to bot.readyTimestamp

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,8 @@ function uptime(bot, config) {
   const format = config.format || 'Uptime: {{hour}} hours, {{minute}} minutes, and {{second}} seconds';
   return function run(message) {
     const now = new Date();
-    const duration = new Duration(bot.readyTime, now);
+    const readyTime = new Date(bot.readyTimestamp);
+    const duration = new Duration(readyTime, now);
     message.reply(pixie.render(format, duration));
   }
 }


### PR DESCRIPTION
In the latest discord.js version bot.readyTime is not available anymore. We updated cordlr to the latest discord.js version (11.0.0) cordlr-uptime is not working anymore without this small fix.